### PR TITLE
Add configurable embeddings for historian lore retrieval

### DIFF
--- a/LORE.txt
+++ b/LORE.txt
@@ -1,0 +1,5 @@
+The Crystal of Dawn was forged from the first sunrise after the Shattering. Its light can cure shadow-blight when held above the afflicted heart at dawn.
+
+Legends say the Whispering Catacombs beneath Mirewatch keep records of every hero who fell defending the realm. Only those who speak their true name aloud may pass unharmed.
+
+The Stormlit Isles are ringed by lightning-charged reefs. Navigators rely on stormglass compasses, but a phoenix feather points directly toward the hidden harbor.


### PR DESCRIPTION
## Summary
- replace the historian's FakeEmbeddings usage with a configurable factory that prefers OpenAI embeddings and falls back to lightweight hashing vectors
- expose `set_embeddings_factory` so production can inject real embeddings and tests can swap in stubs
- add a sample `LORE.txt` so lore retrieval has real content to surface

## Testing
- python - <<'PY'
import sys, types, math
from typing import List

# (dependency stubs omitted for brevity; see command history)
# ...stubs created here...

from AgenticGM import historian, GameState

state: GameState = {
    "user_message": "Tell me about the catacombs guardians.",
    "query": "catacombs guardians true name",
    "lore": "",
    "history": [],
    "story": "",
    "dice_roll": 0,
    "inventory": {},
    "turn_count": 0,
    "require_qm": False,
    "inventory_delta": None,
    "output": "",
}

result = historian(state)
print("Selected lore:\n", result["lore"])
PY

------
https://chatgpt.com/codex/tasks/task_e_68e6f7ba7998832580fec704e4fbcd47